### PR TITLE
Only copy in relevant files to the container.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,14 @@
 FROM python:3.7-slim-stretch
 
-COPY . /wv
+# Copy only the relevant Python files into the container.
+COPY ./lib /wv/lib
+COPY requirements.txt /wv
+COPY wv.py /wv
+
+# Set the work directory to the app folder.
 WORKDIR /wv
 
+# Install Python dependencies.
 RUN pip3 install -r requirements.txt
 
 ENTRYPOINT ["python3", "wv.py"]


### PR DESCRIPTION
Add some labels to the Dockerfile. Also only copy in what the container needs to run instead of things only useful in the repo, like `assets/` and the README.